### PR TITLE
if label is numeric, prevents replacement recycling

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,7 +4,10 @@ Encoding: UTF-8
 Title: Labelled Data Utility Functions
 Version: 1.1.0
 Date: 2019-06-06
-Authors@R: person("Daniel", "Lüdecke", role = c("aut", "cre"), email = "d.luedecke@uke.de", comment = c(ORCID = "0000-0002-8895-3206"))
+Authors@R: c(
+    person("Daniel", "Lüdecke", role = c("aut", "cre"), email = "d.luedecke@uke.de", comment = c(ORCID = "0000-0002-8895-3206"),
+    person("David", "Ranzolin", role = "ctb", email = "daranzolin@gmail.com")
+    )
 Maintainer: Daniel Lüdecke <d.luedecke@uke.de>
 Description: Collection of functions dealing with labelled data, like reading and 
     writing data between R and other statistical software packages like 'SPSS',

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,7 +5,7 @@ Title: Labelled Data Utility Functions
 Version: 1.1.0
 Date: 2019-06-06
 Authors@R: c(
-    person("Daniel", "Lüdecke", role = c("aut", "cre"), email = "d.luedecke@uke.de", comment = c(ORCID = "0000-0002-8895-3206"),
+    person("Daniel", "Lüdecke", role = c("aut", "cre"), email = "d.luedecke@uke.de", comment = c(ORCID = "0000-0002-8895-3206")),
     person("David", "Ranzolin", role = "ctb", email = "daranzolin@gmail.com")
     )
 Maintainer: Daniel Lüdecke <d.luedecke@uke.de>

--- a/R/to_label.R
+++ b/R/to_label.R
@@ -249,7 +249,12 @@ as_label_helper <- function(x, add.non.labelled, prefix, var.label, drop.na, dro
       # remove attributes
       x <- remove_all_labels(x)
     } else {
-      for (i in seq_len(length(vl))) x[x == vn[i]] <- vl[i]
+      for (i in seq_len(length(vl))) {
+        #if label is number, prevents loop from replacing again
+        x[x == vn[i]] <- paste0(vl[i], "_X_")
+      }
+      # remove suffix
+      x <- gsub("_X_$", "", x)
       # to factor
       x <- factor(x, levels = unique(vl))
     }


### PR DESCRIPTION
If the label is also a number, `as_label` will continue updating the value. Here's what was happening to us:

![as_label_pr](https://user-images.githubusercontent.com/9537384/62403336-58deaa00-b541-11e9-8ec3-18a6a7b58370.PNG)
