### PR TITLE
Fix for haven 2.3.0

### DIFF
--- a/R/as_label.R
+++ b/R/as_label.R
@@ -189,6 +189,9 @@ as_label_helper <- function(x, add.non.labelled, prefix, var.label, drop.na, dro
   # get labels
   labels <- NULL
 
+  # Convert to character
+  x <- as.character(x)
+
   # keep missings?
   if (!drop.na) {
     # get NA


### PR DESCRIPTION
Minimal reprex:

``` r
library(haven)
library(sjlabelled, warn.conflicts = FALSE)

x <- labelled(
  c(1:3, tagged_na("a", "c", "z"), 4:1, 2:3),
  c("Agreement" = 1, "Disagreement" = 4, "First" = tagged_na("c"),
    "Refused" = tagged_na("a"), "Not home" = tagged_na("z"))
)

as_label(x, drop.na = FALSE)
#> Error: Can't convert <character> to <labelled<double>>.
as_label(x, drop.na = TRUE)
#> Error: Can't convert <character> to <labelled<double>>.
```

<sup>Created on 2020-05-19 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

I'm not sure what the correct fix is here — the problem is that this is now an error:

```R
x[haven::is_tagged_na(x)] <- dummy_na[haven::is_tagged_na(x)]
```

because the left hand side is a labelled<integer> and the right-hand side is a character vector. My fix just turns the whole thing into a character vector. This at least gets R CMD check passing again.

I'm planning on releasing haven to CRAN later this week.